### PR TITLE
build: Use Kotlin DSL accessors in build.gradle.kts files

### DIFF
--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -49,6 +49,6 @@ dependencies {
     testImplementation(local.ktor.client.content.negotiation)
 }
 
-tasks.withType<Test> {
+tasks.test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
Take advantage of the features of Kotlin DSL by using accessors in `build.gradle.kts` files.